### PR TITLE
Add cache behavior upfront, and note that priming is over HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1001,7 +1001,7 @@
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">HSTS Priming</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2015-11-06">6 November 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2015-11-07">7 November 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1014,7 +1014,7 @@
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 6 November 2015,
+In addition, as of 7 November 2015,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -1128,8 +1128,10 @@ migrations from HTTP to HTTPS.</p>
 <pre>&lt;script src="http://origin-b/widget.js">&lt;/script>
 </pre>
     <p>Before blocking this insecure request as mixed content, the user agent
-  performs an HSTS priming request to the root of the resource’s host, as
-  follows:</p>
+  checks whether the request <a data-link-type="dfn" href="#matches-the-hsts-cache">matches its HSTS
+  cache</a>.</p>
+    <p>If the resource did not match the HSTS cache, the user agent performs an HSTS
+  priming request over HTTPS to the root of the resource’s host, as follows:</p>
 <pre>HEAD / HTTP/1.1
 Host: origin-b
 ...

--- a/index.src.html
+++ b/index.src.html
@@ -130,8 +130,11 @@ spec: RFC6797; urlPrefix: https://tools.ietf.org/html/rfc6797
   </pre>
 
   Before blocking this insecure request as mixed content, the user agent
-  performs an HSTS priming request to the root of the resource's host, as
-  follows:
+  checks whether the request <a lt="matches the HSTS cache">matches its HSTS
+  cache</a>.
+
+  If the resource did not match the HSTS cache, the user agent performs an HSTS
+  priming request over HTTPS to the root of the resource's host, as follows:
 
   <pre>
     HEAD / HTTP/1.1
@@ -146,7 +149,7 @@ spec: RFC6797; urlPrefix: https://tools.ietf.org/html/rfc6797
     ...
     Strict-Transport-Security: max-age=10886400; includeSubDomains
   </pre>
-    
+
   The user agent can then safely upgrade the initial request from HTTP to HTTPS,
   rather than blocking it as mixed content.
 
@@ -211,7 +214,7 @@ spec: RFC6797; urlPrefix: https://tools.ietf.org/html/rfc6797
           :   <a for="HSTS cache entry">host</a>
           ::  |response|'s <a for="request">url</a>'s <a for="url">host</a>
           :   <a for="HSTS cache entry">expiration</a>
-          ::  
+          ::
               ISSUE: Parse the header.
           :   <a for="HSTS cache entry">subdomains</a>
           ::
@@ -266,7 +269,7 @@ spec: RFC6797; urlPrefix: https://tools.ietf.org/html/rfc6797
       :   <a for="HSTS cache entry">host</a>
       ::  |primer|'s <a for="request">url</a>'s <a for="url">host</a>
       :   <a for="HSTS cache entry">expiration</a>
-      ::  A reasonable expiration. Perhaps 24 hours? 
+      ::  A reasonable expiration. Perhaps 24 hours?
       :   <a for="HSTS cache entry">subdomains</a>
       ::  "`exclude`"
       :   <a for="HSTS cache entry">status</a>
@@ -298,9 +301,9 @@ spec: RFC6797; urlPrefix: https://tools.ietf.org/html/rfc6797
 
   2.  |entry|'s <a for="HSTS cache entry">host</a> is a <a>concurrent match</a>
       for |request|'s <a for="request">current url</a>'s <a for="url">host</a>
-      
+
       or
-      
+
       |entry|'s <a for="HSTS cache entry">subdomains</a> is "`include`", and
       |entry|'s <a for="HSTS cache entry">host</a> is a <a>superdomain match</a>
       for |request|'s <a for="request">current url</a>'s <a for="url">host</a>


### PR DESCRIPTION
This adds the HSTS cache check into the topmost description, so that newcomers to the idea don't mistakenly get the impression that this will cause browsers to issue endless HTTPS HEAD requests for every observed insecure resource.

It also makes explicit that the HSTS priming request is over HTTPS.
